### PR TITLE
Improve log function to preserve arguments

### DIFF
--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -2,7 +2,10 @@
 # pve-nut-shutdown  – called by NUT when FSD fires
 set -eu
 
-log()  { logger -t NUT-SHUTDOWN "$*"; echo "$*"; }
+log() {
+    logger -t NUT-SHUTDOWN -- "$@"
+    printf '%s\n' "$*"
+}
 
 # 0. Make absolutely sure we only run once per node
 if systemctl --quiet is-system-running | grep -q "stopping"; then


### PR DESCRIPTION
## Summary
- use logger with -- and printf to handle arguments safely

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_688fe632f11c8324a71bfea48dc6dfee