### PR TITLE
Add pipefail to NUT shutdown script

### DIFF
--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # pve-nut-shutdown  – called by NUT when FSD fires
-set -eu
+set -euo pipefail
 
 log() {
     logger -t NUT-SHUTDOWN -- "$@"


### PR DESCRIPTION
## Summary
- exit on pipeline failures in pve-nut-shutdown

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_688fe6d7d6808324a4948c3ed8656d53