### PR TITLE
Use while loops to process VM and CT IDs

### DIFF
--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -26,11 +26,11 @@ systemctl stop pve-ha-crm pve-ha-lrm watchdog-mux
 sleep 8
 
 # 4. Gracefully shut down every guest that is still running here
-for vid in $(qm  list --noheader | awk '{print $1}');  do
-    qm shutdown   "$vid" --timeout 60 >/dev/null 2>&1 || true
+qm list --noheader | awk '{print $1}' | while read -r vid; do
+    qm shutdown "$vid" --timeout 60 >/dev/null 2>&1 || true
 done
-for cid in $(pct list --noheader | awk '{print $1}'); do
-    pct shutdown  "$cid" --timeout 60 >/dev/null 2>&1 || true
+pct list --noheader | awk '{print $1}' | while read -r cid; do
+    pct shutdown "$cid" --timeout 60 >/dev/null 2>&1 || true
 done
 
 # 5. Wait up to five minutes for guests to die cleanly


### PR DESCRIPTION
## Summary
- Replace command-substitution for loops with pipelines feeding IDs into `while read -r` loops for both VMs and containers

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_688fe7c415648324886eae50474247dd