### PR TITLE
Anchor pgrep pattern

### DIFF
--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -34,7 +34,7 @@ for cid in $(pct list --noheader | awk '{print $1}'); do
 done
 
 # 5. Wait up to five minutes for guests to die cleanly
-timeout=300; while pgrep -f 'kvm|lxc-start' >/dev/null && [ $timeout -gt 0 ]; do
+timeout=300; while pgrep -f '^(kvm|lxc-start)$' >/dev/null && [ $timeout -gt 0 ]; do
     sleep 5; timeout=$((timeout-5))
 done
 


### PR DESCRIPTION
## Summary
- anchor kvm/lxc pgrep pattern to match exact commands

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_688fe83a80a483248913b52a8622fdc1