### PR TITLE
Use /bin/sh for pve-nut-shutdown

### DIFF
--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # pve-nut-shutdown  – called by NUT when FSD fires
-set -euo pipefail
+set -eu
 
 log() {
     logger -t NUT-SHUTDOWN -- "$@"


### PR DESCRIPTION
## Summary
- use /bin/sh as the interpreter for `pve-nut-shutdown`
- drop Bash-specific `pipefail` option for POSIX compliance

## Testing
- `sh -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md`


------
https://chatgpt.com/codex/tasks/task_e_688fe8fa9bb48324bfcf08a018cc74cd