### PR TITLE
Improve shutdown script safeguards and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ venv/
 .venv/
 ENV/
 
+# Node
+node_modules/
+package-lock.json
+
 # Logs
 *.log
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Before committing changes, run the following checks:
   - `bash -n pve-nut-shutdown`
   - `shellcheck pve-nut-shutdown`
-  - `markdownlint README.md`
+  - `markdownlint README.md AGENTS.md`
 
 If `shellcheck` or `markdownlint` is not installed, install them with
 `apt-get install -y shellcheck` and `npm install -g markdownlint-cli`.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ can run even if the cluster is losing quorum.
 
 | Step | Purpose |
 | ---- | ------- |
+| Check node status | Exit if system is already stopping. |
 | Enable node maintenance | Freeze HA scheduler to prevent migrations/fencing. |
 | Stop HA daemons | Prevent services from restarting during shutdown. |
 | Sleep 8 seconds | Give the CRM time to write status. |

--- a/pve-nut-shutdown
+++ b/pve-nut-shutdown
@@ -8,7 +8,7 @@ log() {
 }
 
 # 0. Make absolutely sure we only run once per node
-if systemctl --quiet is-system-running | grep -q "stopping"; then
+if [ "$(systemctl is-system-running 2>/dev/null)" = "stopping" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- avoid rerunning shutdown helper if the system is already stopping
- document the new safeguard and lint instructions
- ignore Node assets in version control

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_688fea761f1083248d6d24e2fe328a94