### PR TITLE
docs: explain maintenance mode usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ outage. It is typically triggered by
 The script is self-contained—it does not rely on SSH or extra packages, so it
 can run even if the cluster is losing quorum.
 
+## Planned maintenance
+
+If you need to drain a node for planned work, run the script manually with
+`--maintenance`:
+
+```bash
+pve-nut-shutdown --maintenance
+```
+
+The script will place the node into maintenance mode and stop guests
+gracefully. NUT continues to call the script without arguments on FSD events.
+
 ## What the script does
 
 | Step | Purpose |


### PR DESCRIPTION
## Summary
- Document how to run `pve-nut-shutdown --maintenance` for planned work
- Note that NUT still calls the script without arguments on FSD events

## Testing
- `bash -n pve-nut-shutdown`
- `shellcheck pve-nut-shutdown`
- `markdownlint README.md AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_689273909170832492271afe7fe9b8f2